### PR TITLE
feat: per browser user agent

### DIFF
--- a/common/webview_handler.cc
+++ b/common/webview_handler.cc
@@ -380,10 +380,6 @@ void WebviewHandler::OnLoadError(CefRefPtr<CefBrowser> browser,
 void WebviewHandler::OnLoadStart(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
                                  CefLoadHandler::TransitionType transition_type)
 {
-    if (onLoadStart)
-    {
-        onLoadStart(browser->GetIdentifier(), frame->GetURL());
-    }
     return;
 }
 
@@ -1026,4 +1022,20 @@ void WebviewHandler::OnPaint(CefRefPtr<CefBrowser> browser, CefRenderHandler::Pa
     {
         onPaintCallback(browserId, buffer, w, h);
     }
+}
+
+bool WebviewHandler::OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, bool user_gesture, bool is_redirect) 
+{
+    if (onLoadStart)
+    {
+        onLoadStart(browser->GetIdentifier(), frame->GetURL());
+    }
+    return false;
+}
+
+
+cef_return_value_t WebviewHandler::OnBeforeResourceLoad(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, CefRefPtr<CefCallback> callback)
+{
+    request->SetHeaderByName("User-Agent", "TestValue/2", true);
+    return RV_CONTINUE;
 }

--- a/common/webview_handler.cc
+++ b/common/webview_handler.cc
@@ -62,12 +62,14 @@ namespace
                       std::string url,
                       std::string dataPath,
                       std::string locale,
+                      std::string userAgent,
                       bool deleteCookiesOnInit,
                       std::function<void(int)> callback)
             : handler_(handler),
               url_(std::move(url)),
               dataPath_(std::move(dataPath)),
               locale_(std::move(locale)),
+              userAgent_(std::move(userAgent)),
               callback_(std::move(callback)) {}
 
         void OnRequestContextInitialized(CefRefPtr<CefRequestContext> context) override
@@ -75,14 +77,14 @@ namespace
             // Always marshal to UI before creating a browser
             CefPostTask(TID_UI, base::BindOnce(&WebviewHandler::createBrowserOnUI,
                                                handler_, url_, dataPath_, locale_,
-                                               context, callback_));
+                                               userAgent_, context, callback_));
         }
 
         IMPLEMENT_REFCOUNTING(RcInitHandler);
 
     private:
         WebviewHandler *handler_;
-        std::string url_, dataPath_, locale_;
+        std::string url_, dataPath_, locale_, userAgent_;
         std::function<void(int)> callback_;
     };
 
@@ -425,6 +427,7 @@ bool WebviewHandler::IsChromeRuntimeEnabled()
 void WebviewHandler::cleanUpBrowser(int browserId)
 {
     auto it = browser_map_.find(browserId);
+    user_agent_overrides_.erase(browserId);
     if (it != browser_map_.end())
     {
         it->second.browser = nullptr;
@@ -452,7 +455,7 @@ void WebviewHandler::closeBrowser(int browserId)
     }
 }
 
-CefRefPtr<CefRequestContext> WebviewHandler::createContext(const std::string &url, const std::string &dataPath, const std::string &locale, bool deleteCookiesOnInit, std::function<void(int)> callback)
+CefRefPtr<CefRequestContext> WebviewHandler::createContext(const std::string &url, const std::string &dataPath, const std::string &locale, const std::string &userAgent, bool deleteCookiesOnInit, std::function<void(int)> callback)
 {
     CefRequestContextSettings cs;
     CefString(&cs.cache_path) = dataPath;
@@ -463,7 +466,7 @@ CefRefPtr<CefRequestContext> WebviewHandler::createContext(const std::string &ur
         CefString(&cs.accept_language_list) = locale + ",en";
     }
 
-    auto handler = new RcInitHandler(this, url, dataPath, locale, deleteCookiesOnInit, callback);
+    auto handler = new RcInitHandler(this, url, dataPath, locale, userAgent, deleteCookiesOnInit, callback);
     auto ctx = CefRequestContext::CreateContext(cs, handler);
 
     auto mgr = ctx->GetCookieManager(nullptr);
@@ -506,6 +509,7 @@ void WebviewHandler::createBrowser(std::string url, std::function<void(int)> cal
 void WebviewHandler::createBrowserOnUI(std::string url,
                                        std::string dataPath,
                                        std::string locale,
+                                       std::string userAgent,
                                        CefRefPtr<CefRequestContext> ctx,
                                        std::function<void(int)> callback)
 {
@@ -523,13 +527,15 @@ void WebviewHandler::createBrowserOnUI(std::string url,
 
     CefRefPtr<CefBrowser> browser =
         CefBrowserHost::CreateBrowserSync(wi, this, url, bs, nullptr, ctx);
-
+    if (!userAgent.empty())
+        user_agent_overrides_.insert_or_assign(browser->GetIdentifier(), userAgent);
     callback(browser->GetIdentifier());
 }
 
 void WebviewHandler::createBrowserWithOptions(std::string url,
                                               std::string dataPath,
                                               std::string locale,
+                                              std::string userAgent,
                                               bool deleteCookiesOnInit,
                                               std::function<void(int)> callback)
 {
@@ -537,11 +543,10 @@ void WebviewHandler::createBrowserWithOptions(std::string url,
     if (!CefCurrentlyOn(TID_UI))
     {
         CefPostTask(TID_UI, base::BindOnce(&WebviewHandler::createBrowserWithOptions,
-                                           this, url, dataPath, locale, deleteCookiesOnInit, callback));
+                                           this, url, dataPath, locale, userAgent, deleteCookiesOnInit, callback));
         return;
     }
 #endif
-
     // Validate dataPath: absolute + usable + under root (if root is set)
     if (!dataPath.empty())
     {
@@ -552,7 +557,7 @@ void WebviewHandler::createBrowserWithOptions(std::string url,
         }
     }
 
-    createContext(url, dataPath, locale, deleteCookiesOnInit, callback);
+    createContext(url, dataPath, locale, userAgent, deleteCookiesOnInit, callback);
 }
 
 void WebviewHandler::sendScrollEvent(int browserId, int x, int y, int deltaX, int deltaY)
@@ -1028,7 +1033,7 @@ bool WebviewHandler::OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<Cef
 {
     if (onLoadStart)
     {
-        onLoadStart(browser->GetIdentifier(), frame->GetURL());
+        onLoadStart(browser->GetIdentifier(), request->GetURL());
     }
     return false;
 }
@@ -1036,6 +1041,9 @@ bool WebviewHandler::OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<Cef
 
 cef_return_value_t WebviewHandler::OnBeforeResourceLoad(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, CefRefPtr<CefCallback> callback)
 {
-    request->SetHeaderByName("User-Agent", "TestValue/2", true);
+    auto ua_iter = user_agent_overrides_.find(browser->GetIdentifier());
+    if (ua_iter != user_agent_overrides_.end()) {
+        request->SetHeaderByName("User-Agent", ua_iter->second, true);
+    }
     return RV_CONTINUE;
 }

--- a/common/webview_handler.h
+++ b/common/webview_handler.h
@@ -162,7 +162,9 @@ public:
     virtual void OnImeCompositionRangeChanged(CefRefPtr<CefBrowser> browser, const CefRange &selection_range, const CefRenderHandler::RectList &character_bounds) override;
 
 
+    // CefRequestHandler
     virtual bool OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, bool user_gesture, bool is_redirect) override;
+    // CefResourceRequestHandler
     virtual ReturnValue OnBeforeResourceLoad (CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, CefRefPtr<CefCallback> callback) override;
 
     // Request that all existing browser windows close.
@@ -173,10 +175,11 @@ public:
 
     void closeBrowser(int browserId);
     void createBrowser(std::string url, std::function<void(int)> callback);
-    void createBrowserWithOptions(std::string url, std::string dataPath, std::string locale, bool deleteCookiesOnInit, std::function<void(int)> callback);
+    void createBrowserWithOptions(std::string url, std::string dataPath, std::string locale, std::string userAgent, bool deleteCookiesOnInit, std::function<void(int)> callback);
     void createBrowserOnUI(std::string url,
                            std::string dataPath,
                            std::string locale,
+                           std::string userAgent,
                            CefRefPtr<CefRequestContext> ctx,
                            std::function<void(int)> callback);
 
@@ -208,10 +211,13 @@ public:
 
 private:
     void cleanUpBrowser(int browserId);
-    CefRefPtr<CefRequestContext> createContext(const std::string &url, const std::string &dataPath, const std::string &locale, bool deleteCookiesOnInit, std::function<void(int)> callback);
+    CefRefPtr<CefRequestContext> createContext(const std::string &url, const std::string &dataPath, const std::string &locale, const std::string &userAgent, bool deleteCookiesOnInit, std::function<void(int)> callback);
 
     // List of existing browser windows. Only accessed on the CEF UI thread.
     std::unordered_map<int, browser_info> browser_map_;
+
+    // Map of user agent override per browser id
+    std::unordered_map<int, std::string> user_agent_overrides_;
 
     std::unordered_map<std::string, std::function<void(CefRefPtr<CefValue>)>> js_callbacks_;
     // Include the default reference counting implementation.

--- a/common/webview_handler.h
+++ b/common/webview_handler.h
@@ -40,7 +40,9 @@ class WebviewHandler : public CefClient,
                        public CefLifeSpanHandler,
                        public CefFocusHandler,
                        public CefLoadHandler,
-                       public CefRenderHandler
+                       public CefRenderHandler,
+                       public CefRequestHandler,
+                       public CefResourceRequestHandler
 {
 public:
     // Paint callback
@@ -78,6 +80,15 @@ public:
     {
         return this;
     }
+    virtual CefRefPtr<CefRequestHandler> GetRequestHandler() override
+    {
+        return this;
+    }
+    virtual CefRefPtr<CefResourceRequestHandler> GetResourceRequestHandler(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, bool is_navigation, bool is_download, const CefString &request_initiator, bool &disable_default_handling) override 
+    {
+        return this;
+    }
+    
     virtual CefRefPtr<CefLoadHandler> GetLoadHandler() override { return this; }
     virtual CefRefPtr<CefRenderHandler> GetRenderHandler() override { return this; }
 
@@ -149,6 +160,10 @@ public:
                                int x,
                                int y) override;
     virtual void OnImeCompositionRangeChanged(CefRefPtr<CefBrowser> browser, const CefRange &selection_range, const CefRenderHandler::RectList &character_bounds) override;
+
+
+    virtual bool OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, bool user_gesture, bool is_redirect) override;
+    virtual ReturnValue OnBeforeResourceLoad (CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, CefRefPtr<CefCallback> callback) override;
 
     // Request that all existing browser windows close.
     void CloseAllBrowsers(bool force_close);

--- a/common/webview_plugin.cc
+++ b/common/webview_plugin.cc
@@ -336,6 +336,7 @@ namespace webview_cef
 			std::string dataPath = "";
 			std::string locale = "";
 			bool deleteCookiesOnInit = false;
+			std::string userAgent = "";
 
 			// Get dataPath if provided (can be null)
 			WValue *dataPathValue = webview_value_get_list_value(values, 1);
@@ -358,7 +359,13 @@ namespace webview_cef
 				deleteCookiesOnInit = webview_value_get_bool(deleteCookiesValue);
 			}
 
-			m_handler->createBrowserWithOptions(url, dataPath, locale, deleteCookiesOnInit, [=](int browserId)
+			WValue *userAgentValue = webview_value_get_list_value(values, 4);
+			if (userAgentValue && webview_value_get_type(userAgentValue) == Webview_Value_Type_String)
+			{
+				userAgent = webview_value_get_string(userAgentValue);
+			}
+
+			m_handler->createBrowserWithOptions(url, dataPath, locale, userAgent, deleteCookiesOnInit, [=](int browserId)
 												{
 				std::shared_ptr<WebviewTexture> renderer = m_createTextureFunc();
 				m_renderers[browserId] = renderer;
@@ -755,7 +762,7 @@ namespace webview_cef
 
 		char default_ua[256];
 		snprintf(default_ua, sizeof(default_ua),
-				 "Chrome/%s Safari/537.36",
+				 "Chrome/%s",
 				 GetChromeVersionString().c_str());
 		std::string ua = userAgent.empty() ? default_ua : userAgent;
 

--- a/common/webview_plugin.cc
+++ b/common/webview_plugin.cc
@@ -755,7 +755,6 @@ namespace webview_cef
 
 		char default_ua[256];
 		snprintf(default_ua, sizeof(default_ua),
-				 "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
 				 "Chrome/%s Safari/537.36",
 				 GetChromeVersionString().c_str());
 		std::string ua = userAgent.empty() ? default_ua : userAgent;

--- a/lib/src/webview.dart
+++ b/lib/src/webview.dart
@@ -14,12 +14,13 @@ import 'webview_tooltip.dart';
 
 class WebViewController extends ValueNotifier<bool> {
   WebViewController(this._pluginChannel, this._index,
-      {Widget? loading, String? dataPath, String? locale, bool? deleteCookiesOnInit})
+      {Widget? loading, String? dataPath, String? locale, bool? deleteCookiesOnInit, String? userAgent})
       : super(false) {
     _loadingWidget = loading;
     _dataPath = dataPath;
     _locale = locale;
     _deleteCookiesOnInit = deleteCookiesOnInit;
+    _userAgent = userAgent;
   }
 
   WebViewController.createPopup(
@@ -37,6 +38,7 @@ class WebViewController extends ValueNotifier<bool> {
   Widget? _loadingWidget;
   String? _dataPath;
   String? _locale;
+  String? _userAgent;
   bool? _deleteCookiesOnInit;
   bool _isPageLoading = false;
 
@@ -93,9 +95,10 @@ class WebViewController extends ValueNotifier<bool> {
     try {
       await WebviewManager().ready;
       List args;
-      if (_dataPath != null || _locale != null || _deleteCookiesOnInit == true) {
+      final ua = _userAgent ?? '';
+      if (_dataPath != null || _locale != null || _deleteCookiesOnInit == true || ua.isNotEmpty) {
         args = await _pluginChannel
-            .invokeMethod('createWithOptions', [url, _dataPath, _locale, _deleteCookiesOnInit ?? false]);
+            .invokeMethod('createWithOptions', [url, _dataPath, _locale, _deleteCookiesOnInit ?? false, ua]);
       } else {
         args = await _pluginChannel.invokeMethod('create', url);
       }

--- a/lib/src/webview_manager.dart
+++ b/lib/src/webview_manager.dart
@@ -36,10 +36,11 @@ class WebviewManager extends ValueNotifier<bool> {
     String? dataPath,
     String? locale,
     bool? deleteCookiesOnInit,
+    String? userAgent,
   }) {
     int browserIndex = nextIndex++;
     final controller = WebViewController(pluginChannel, browserIndex,
-        loading: loading, dataPath: dataPath, locale: locale, deleteCookiesOnInit: deleteCookiesOnInit);
+        loading: loading, dataPath: dataPath, locale: locale, deleteCookiesOnInit: deleteCookiesOnInit, userAgent: userAgent);
     _tempWebViews[browserIndex] = controller;
     _tempInjectUserScripts[browserIndex] =
         injectUserScripts ?? InjectUserScripts();


### PR DESCRIPTION
this introduces a way to specify user agent when creating a webview with options, it is done by intercepting each resource request and replacing User-Agent header if such override is defined.

This also changes a behavior of
- constructing the default user agent - we were incorrectly setting the product part with the copy of a full user agent string
- onLoadStart is triggered OnBeforeBrowse now.

Default user agent is now correctly
```
Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.7204.101 Safari/537.36
```
instead of
```
Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.7204.101 Safari/537.36
```